### PR TITLE
Ets 1169 linklist 25 is diplayed at 100 percent width

### DIFF
--- a/source/_patterns/03-templates/versace.mustache
+++ b/source/_patterns/03-templates/versace.mustache
@@ -1,6 +1,5 @@
 {{> organisms-header }}
 {{> organisms-page-headline }}
-{{> molecules-header-cookie-box }}
 <main role="main" class="container">
 
  ... versace ...

--- a/source/scss/components/_link-list.scss
+++ b/source/scss/components/_link-list.scss
@@ -1,7 +1,7 @@
 /* link-list - yes, the wrapper */
 .link-list {
   display: flex;
-  flex-wrap: wrap; 
+  flex-wrap: wrap;
   width: 100%;
 }
 
@@ -10,7 +10,7 @@
   margin-bottom: $grid-gutter-width;
   padding-left: $grid-gutter-width / 2;
   padding-right: $grid-gutter-width / 2;
-  
+
   ul li a {
     font-size: .75rem;
   }

--- a/source/scss/components/_link-list.scss
+++ b/source/scss/components/_link-list.scss
@@ -1,9 +1,8 @@
 /* link-list - yes, the wrapper */
 .link-list {
   display: flex;
-  flex-wrap: wrap;
-  margin-left: ($grid-gutter-width / 2 * -1);
-  margin-right: ($grid-gutter-width / 2 * -1);
+  flex-wrap: wrap; 
+  width: 100%;
 }
 
 .link-list-25 {
@@ -11,7 +10,7 @@
   margin-bottom: $grid-gutter-width;
   padding-left: $grid-gutter-width / 2;
   padding-right: $grid-gutter-width / 2;
-
+  
   ul li a {
     font-size: .75rem;
   }


### PR DESCRIPTION
Link list is now 100%
Removed margin to solve spacing conflicts

Removed the molecule call to the cookie box