### PR TITLE
Ets 1586 delay on open submenu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.27.4
+- Adds delay when opening sub menu on desktop
+- Prevents bubbling on mouseout by using mouseleave
+
 ## 0.27.3
 - Reverses transition behaviour, to avoid Quicksearch not being accessible
 

--- a/source/js/header-navigation.js
+++ b/source/js/header-navigation.js
@@ -49,14 +49,12 @@ desktopMenuItems.forEach( function(element) {
   if (subMenu) { // Ignores menu items with no children
     element.addEventListener("mouseover", function(event) {
       if (event.target === this || this.hasChildNodes(event.target)) {
-        event.preventDefault();
         openSubMenu(element);
         toggleLeftShift();
       }
     });
-    element.addEventListener("mouseout", function(event) {
+    element.addEventListener("mouseleave", function(event) {
       if (event.target === this || this.hasChildNodes(event.target)) {
-        event.preventDefault();
         closeSubMenu(element);
         toggleLeftShift();
       }

--- a/source/scss/components/header-menu/_header-sub-menu.scss
+++ b/source/scss/components/header-menu/_header-sub-menu.scss
@@ -11,6 +11,17 @@
   padding-left: $content-padding-15 * 2;
 }
 
+// LG:
+// for IE11 it needs to be outside of a media query
+@keyframes delay-open-subMenu {
+  0% { opacity: 0; }
+  100% { opacity: 1; }
+}
+
+.header-menu .header-sub-menu-container.display-block {
+  animation: delay-open-subMenu .5s;
+}
+
 @include media-breakpoint-up(lg) { //>960
   .header-sub-menu-container {
     background-color: $white;


### PR DESCRIPTION
## 0.27.4
- Adds delay when opening sub menu on desktop using keyframes
- Prevents bubbling on mouseout by using mouseleave

The keyframes need to be used outside of a media query since IE11 has introduced a bug that doesn't make it possible. To make sure, that no one is accidentally putting it into a media query I leave a comment there.