### PR TITLE
ETS-1660 Fixes JS bug related to the Skyscraper ad. Suggests version 0.30.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.29.5
+- Fixes JS bug related to the Skyscraper ad 
+
 ## 0.29.4
 - Adds core-js to the bundle so it includes the polyfills directly from our bundle
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## 0.29.5
+## 0.30.1
 - Fixes JS bug related to the Skyscraper ad 
 
 ## 0.29.4

--- a/source/js/google-ads.js
+++ b/source/js/google-ads.js
@@ -2,7 +2,10 @@ var adjustSkyscraperPositioning = function() {
   var mainElement = document.getElementsByTagName("main")[0];
   if (mainElement) {
     var newHeight = mainElement.offsetTop;
-    document.getElementsByClassName("ad-skyscraper-wrapper")[0].style.top = newHeight + "px";
+    var skyscraper = document.getElementsByClassName("ad-skyscraper-wrapper")[0];
+    if (skyscraper) {
+      skyscraper.style.top = newHeight + "px";
+    }
   }
 };
 


### PR DESCRIPTION
The skyscraper was not being tested for existence on its original JS file.

![image](https://user-images.githubusercontent.com/45654887/52559090-98c79e80-2df4-11e9-8094-13bcdf5f4de2.png)
