### PR TITLE
NO-TICKET Skips version 0.32.0 and adds 0.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
-## 0.32.0
+## 0.33.0
 - Adds new Hotel Category images (previously known as 'Stars')
+
+## 0.32.0
+## This version was skipped because of an issue with the repository
+## Refer to https://ftiecom.slack.com/archives/CB3DH5CK0/p1550674129002300
 
 ## 0.31.4
 - Fixes material input border-bottom, implementing input wrapper


### PR DESCRIPTION
We had to skip version 0.32.0 because of some issues with the repository. We are now using version 0.33.0 (new Hotel Category images)

https://ftiecom.slack.com/archives/CB3DH5CK0/p1550674129002300