### PR TITLE
ETS-2326 Teaser containers not needed anymore. Version 0.50.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 All notable changes to this project will be documented in this file.
 
+## 0.50.5
+- Teaser containers are not needed anymore.
+- Adds support for `.main-content.teaser-list`.
+
 ## 0.50.3
 - Improves the Ellipsis feature by decreasing the maximum length of the `.top-offer-title > h3` element.
 

--- a/source/_patterns/03-templates/standard-teaser-list.mustache
+++ b/source/_patterns/03-templates/standard-teaser-list.mustache
@@ -1,0 +1,92 @@
+{{> atoms-ad-leaderboard }}
+{{> atoms-ad-skyscraper }}
+{{> molecules-info-message }}
+{{> organisms-header }}
+{{> organisms-page-headline(content: 'The standard template') }}
+
+<main role="main" class="container">
+  <div class="main-content teaser-list">
+
+    {{> organisms-tabs}}
+
+    {{> atoms-divider }}
+
+    <div class="teaser-list">
+      {{> organisms-content-teaser-50 }}
+      {{> organisms-offer-teaser-50 }}
+    </div>
+
+    <div class="teaser-list">
+      {{> organisms-content-teaser-50 }}
+      {{> organisms-offer-teaser-50 }}
+    </div>
+
+    {{> atoms-divider }}
+
+    <div class="multi-teaser-list">
+      {{> organisms-multioffer-teaser-50 }}
+      {{> organisms-multioffer-teaser-50 }}
+    </div>
+
+    {{> atoms-divider }}
+
+    <div class="teaser-list">
+      {{> organisms-content-teaser-50}}
+      {{> organisms-multioffer-teaser-50 }}
+      {{> organisms-content-teaser-25}}
+      <div class="standard-content width-25">
+        <h2>Regular text (25% width)</h2>
+        <p>Lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum</p>
+      </div>
+      {{> organisms-content-teaser-50}}
+    </div>
+
+    {{> atoms-divider }}
+
+    <div class="teaser-list">
+      <div class="standard-content width-25">
+        <h2>Regular Image 25%</h2>
+        {{> atoms-image-responsive}}
+      </div>
+      {{> organisms-content-teaser-25}}
+      <div class="standard-content width-50">
+      {{> atoms-image-responsive}}
+      </div>
+    </div>
+
+    {{> atoms-divider }}
+
+    <div class="teaser-list">
+      <div class="standard-content width-50">
+        <h2>Regular text (50% width)</h2>
+        <p>Lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum</p>
+      </div>
+      {{> organisms-content-teaser-25}}
+      {{> organisms-content-teaser-25}}
+    </div>
+
+    {{> atoms-divider }}
+
+    <div class="standard-content width-100">
+      <h2>Regular text (full width) outside Teaser-Container</h2>
+      <p>Lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum</p>
+    </div>
+
+    {{> atoms-divider }}
+
+    <div class="teaser-list">
+      <div class="standard-content width-100">
+      <h2>Regular text (full width) inside Teaser-Container</h2>
+      <p>Lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum</p>
+      </div>
+    </div>
+
+    {{> atoms-divider }}
+
+    {{> organisms-linklist-25 }}
+
+    {{> organisms-linklist-single-title }}
+  </div>
+</main>
+
+{{> organisms-footer }}

--- a/source/scss/components/_teaser.scss
+++ b/source/scss/components/_teaser.scss
@@ -47,6 +47,7 @@
     .teaser-list {
       margin-left: ($grid-gutter-width / 2 * -1);
       margin-right: ($grid-gutter-width / 2 * -1);
+      width: calc(100% + #{$grid-gutter-width}); // for IE11
     }
   }
 }

--- a/source/scss/components/_teaser.scss
+++ b/source/scss/components/_teaser.scss
@@ -39,6 +39,16 @@
   flex-wrap: wrap;
   margin-left: ($grid-gutter-width / 2 * -1);
   margin-right: ($grid-gutter-width / 2 * -1);
+
+  &.main-content {
+    margin-left: 0;
+    margin-right: 0;
+
+    .teaser-list {
+      margin-left: ($grid-gutter-width / 2 * -1);
+      margin-right: ($grid-gutter-width / 2 * -1);
+    }
+  }
 }
 
 // teaser - basic structure

--- a/source/scss/components/multioffer-teaser/_multioffer-teaser.scss
+++ b/source/scss/components/multioffer-teaser/_multioffer-teaser.scss
@@ -59,6 +59,10 @@
   margin-right: ($grid-gutter-width / 2 * -1);
 }
 
+.main-content.teaser-list .multi-teaser-list {
+  width: calc(100% + #{$grid-gutter-width}); // for IE11
+}
+
 // Layout
 .multi-teaser-50 {
   @include mo-teaser-subline-layout("xl");

--- a/source/scss/layout/_divider.scss
+++ b/source/scss/layout/_divider.scss
@@ -1,3 +1,4 @@
 hr {
-  margin: $font-size-base * 2.5 0; 
+  margin: $font-size-base * 2.5 0;
+  width: 100%;
 }

--- a/source/scss/layout/_main.scss
+++ b/source/scss/layout/_main.scss
@@ -62,6 +62,17 @@ main {
     padding-left: $grid-gutter-width / 2;
     padding-right: $grid-gutter-width / 2;
   }
+
+  .main-content.teaser-list {
+    .teaser-list .standard-content {
+      padding-left: 15px;
+      padding-right: 15px;
+    }
+
+    .standard-content {
+      padding: 0;
+    }
+  }
 }
 
 /// Main on Desktop view


### PR DESCRIPTION
## 0.50.5
- Teaser containers are not needed anymore.
- Adds support for `.main-content.teaser-list`.
- Adds new template: _Standard With Teaser List_. It is a copy of the _Standard_ template, but a new element with classes `main-content` and `teaser-list` was added as a child of the `<main role="main" class="container">` element.